### PR TITLE
Change lodash method names to match 4.x changes

### DIFF
--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -75,11 +75,11 @@ var expressValidator = function(options) {
 
   // _.set validators and sanitizers as prototype methods on corresponding chains
   _.forEach(validator, function(method, methodName) {
-    if (methodName.match(/^is/) || _.contains(additionalValidators, methodName)) {
+    if (methodName.match(/^is/) || _.includes(additionalValidators, methodName)) {
       ValidatorChain.prototype[methodName] = makeValidator(methodName, validator);
     }
 
-    if (methodName.match(/^to/) || _.contains(additionalSanitizers, methodName)) {
+    if (methodName.match(/^to/) || _.includes(additionalSanitizers, methodName)) {
       Sanitizer.prototype[methodName] = makeSanitizer(methodName, validator);
     }
   });


### PR DESCRIPTION
The _.contains alias was dropped in 4.0.0 in favor of _.includes
